### PR TITLE
feat: improve resolver implementation and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,34 +38,29 @@ Peer dependencies:
 ### Basic fields validation
 
 ```tsx
-import {
-	object,
-	string,
-	minLength,
-	email,
-	number,
-	minValue,
-	pipe,
-} from "valibot";
 import { useForm } from "@mantine/form";
 import { valibotResolver } from "mantine-form-valibot-resolver";
+import * as v from "valibot";
 
-const schema = object({
-	name: pipe(string(), minLength(2, "Name should have at least 2 letters")),
-	email: pipe(string(), email("Invalid email")),
-	age: pipe(
-		number(),
-		minValue(18, "You must be at least 18 to create an account")
-	),
+const schema = v.object({
+  name: v.pipe(
+    v.string(),
+    v.minLength(2, "Name should have at least 2 letters")
+  ),
+  email: v.pipe(v.string(), v.email("Invalid email")),
+  age: v.pipe(
+    v.number(),
+    v.minValue(18, "You must be at least 18 to create an account")
+  ),
 });
 
 const form = useForm({
-	initialValues: {
-		name: "",
-		email: "",
-		age: 16,
-	},
-	validate: valibotResolver(schema),
+  initialValues: {
+    name: "",
+    email: "",
+    age: 16,
+  },
+  validate: valibotResolver(schema),
 });
 
 form.validate();
@@ -80,23 +75,26 @@ form.errors;
 ### Nested fields validation
 
 ```tsx
-import { object, string, minLength, pipe } from "valibot";
 import { useForm } from "@mantine/form";
 import { valibotResolver } from "mantine-form-valibot-resolver";
+import * as v from "valibot";
 
-const nestedSchema = object({
-	nested: object({
-		field: pipe(string(), minLength(2, "Field should have at least 2 letters")),
-	}),
+const nestedSchema = v.object({
+  nested: v.object({
+    field: v.pipe(
+      v.string(),
+      v.minLength(2, "Field should have at least 2 letters")
+    ),
+  }),
 });
 
 const form = useForm({
-	initialValues: {
-		nested: {
-			field: "",
-		},
-	},
-	validate: valibotResolver(nestedSchema),
+  initialValues: {
+    nested: {
+      field: "",
+    },
+  },
+  validate: valibotResolver(nestedSchema),
 });
 
 form.validate();
@@ -109,23 +107,26 @@ form.errors;
 ### List fields validation
 
 ```tsx
-import { object, array, string, minLength, pipe } from "valibot";
 import { useForm } from "@mantine/form";
 import { valibotResolver } from "mantine-form-valibot-resolver";
+import * as v from "valibot";
 
-const listSchema = object({
-	list: array(
-		object({
-			name: pipe(string(), minLength(2, "Name should have at least 2 letters")),
-		})
-	),
+const listSchema = v.object({
+  list: v.array(
+    v.object({
+      name: v.pipe(
+        v.string(),
+        v.minLength(2, "Name should have at least 2 letters")
+      ),
+    })
+  ),
 });
 
 const form = useForm({
-	initialValues: {
-		list: [{ name: "" }],
-	},
-	validate: valibotResolver(listSchema),
+  initialValues: {
+    list: [{ name: "" }],
+  },
+  validate: valibotResolver(listSchema),
 });
 
 form.validate();
@@ -140,21 +141,21 @@ form.errors;
 You can use the `InferInput` type from the `valibot` library to get the type of the form data.
 
 ```tsx
-import { email, object, string, pipe, type InferInput } from "valibot";
 import { useForm } from "@mantine/form";
 import { valibotResolver } from "mantine-form-valibot-resolver";
+import * as v from "valibot";
 
-export const userSchema = object({
-	email: pipe(string(), email()),
+export const userSchema = v.object({
+  email: v.pipe(v.string(), v.email()),
 });
 
-type FormData = InferInput<typeof userSchema>;
+type FormData = v.InferInput<typeof userSchema>;
 
 const form = useForm<FormData>({
-	initialValues: {
-		email: "",
-	},
-	validate: valibotResolver(userSchema),
+  initialValues: {
+    email: "",
+  },
+  validate: valibotResolver(userSchema),
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"tsimp": "^2.0.11",
 		"tsup": "^8.1.0",
 		"typescript": "^5.4.5",
-		"valibot": "0.31.0-rc.11"
+		"valibot": "0.31.0-rc.12"
 	},
 	"peerDependencies": {
 		"@mantine/form": ">=7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^5.4.5
         version: 5.4.5
       valibot:
-        specifier: 0.31.0-rc.11
-        version: 0.31.0-rc.11
+        specifier: 0.31.0-rc.12
+        version: 0.31.0-rc.12
 
 packages:
 
@@ -1414,8 +1414,8 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
-  valibot@0.31.0-rc.11:
-    resolution: {integrity: sha512-WAyZUdU0RP93vl0A8HyCUi5q4oveLjglou4X/Zn7a9T/lQLHb8J376SXjMqaMweG+XBZJ0bU2b156+d/nAlJ+A==}
+  valibot@0.31.0-rc.12:
+    resolution: {integrity: sha512-vAI18A65Og1BwuVqC3Zvr0+yNxOANLHDVo3r5VOTsVItfBl6KcykmY7fioSU5CVSlrj2JgViHjcsfAofO2h0rw==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -2836,7 +2836,7 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
-  valibot@0.31.0-rc.11: {}
+  valibot@0.31.0-rc.12: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
I further improved the implementation by using our new `getDotPath` util. I've also changed the Valibot code in the README to use wildcard imports, as this is now the official recommended way to use Valibot because of the better DX (three shaking still works).