### PR TITLE
feat: update valibot dependency to v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,65 +1,70 @@
 {
-	"name": "mantine-form-valibot-resolver",
-	"version": "2.0.1",
-	"description": "Valibot resolver for @mantine/form validation",
-	"keywords": ["valibot", "mantine", "form", "resolver"],
-	"homepage": "https://github.com/Songkeys/mantine-form-valitbot-resolver#readme",
-	"bugs": {
-		"url": "https://github.com/Songkeys/mantine-form-valibot-resolver/issues"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/Songkeys/mantine-form-valibot-resolver.git"
-	},
-	"license": "MIT",
-	"author": "Songkeys <songv587@gmail.com>",
-	"exports": {
-		".": {
-			"import": {
-				"types": "./dist/index.d.mts",
-				"default": "./dist/index.mjs"
-			},
-			"require": {
-				"types": "./dist/index.d.ts",
-				"default": "./dist/index.js"
-			}
-		}
-	},
-	"main": "./dist/index.js",
-	"module": "./dist/index.mjs",
-	"types": "./dist/index.d.ts",
-	"scripts": {
-		"build": "tsup --dts",
-		"format": "biome format . --write",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --apply",
-		"prepublishOnly": "npm run build",
-		"release": "bumpp",
-		"test": "node --import=tsimp/import --test **/*.test.ts",
-		"typecheck": "tsc --noEmit",
-		"watch": "tsup --watch"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "^1.7.3",
-		"@testing-library/react": "^16.0.0",
-		"@types/node": "^20.14.1",
-		"bumpp": "^9.4.1",
-		"jsdom": "^24.1.0",
-		"simple-git-hooks": "^2.11.1",
-		"tsimp": "^2.0.11",
-		"tsup": "^8.1.0",
-		"typescript": "^5.4.5",
-		"valibot": "0.35.0"
-	},
-	"peerDependencies": {
-		"@mantine/form": ">=7.0.0",
-		"valibot": ">=0.33.0 <1"
-	},
-	"packageManager": "pnpm@9.1.4",
-	"engines": {
-		"node": ">=16.6.0"
-	},
-	"simple-git-hooks": {
-		"pre-commit": "npm run format && npm run lint:fix"
-	}
+  "name": "mantine-form-valibot-resolver",
+  "version": "2.0.1",
+  "description": "Valibot resolver for @mantine/form validation",
+  "keywords": [
+    "valibot",
+    "mantine",
+    "form",
+    "resolver"
+  ],
+  "homepage": "https://github.com/Songkeys/mantine-form-valitbot-resolver#readme",
+  "bugs": {
+    "url": "https://github.com/Songkeys/mantine-form-valibot-resolver/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Songkeys/mantine-form-valibot-resolver.git"
+  },
+  "license": "MIT",
+  "author": "Songkeys <songv587@gmail.com>",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup --dts",
+    "format": "biome format . --write",
+    "lint": "biome check .",
+    "lint:fix": "biome check . --apply",
+    "prepublishOnly": "npm run build",
+    "release": "bumpp",
+    "test": "node --import=tsimp/import --test **/*.test.ts",
+    "typecheck": "tsc --noEmit",
+    "watch": "tsup --watch"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.7.3",
+    "@testing-library/react": "^16.0.0",
+    "@types/node": "^20.14.1",
+    "bumpp": "^9.4.1",
+    "jsdom": "^24.1.0",
+    "simple-git-hooks": "^2.11.1",
+    "tsimp": "^2.0.11",
+    "tsup": "^8.1.0",
+    "typescript": "^5.4.5",
+    "valibot": "1.0.0-beta.0"
+  },
+  "peerDependencies": {
+    "@mantine/form": ">=7.0.0",
+    "valibot": "^1.0.0"
+  },
+  "packageManager": "pnpm@9.1.4",
+  "engines": {
+    "node": ">=16.6.0"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "npm run format && npm run lint:fix"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^5.4.5
         version: 5.4.5
       valibot:
-        specifier: 0.35.0
-        version: 0.35.0
+        specifier: 1.0.0-beta.0
+        version: 1.0.0-beta.0(typescript@5.4.5)
 
 packages:
 
@@ -1414,8 +1414,13 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
-  valibot@0.35.0:
-    resolution: {integrity: sha512-+i2aCRkReTrd5KBN/dW2BrPOvFnU5LXTV2xjZnjnqUIO8YUx6P2+MgRrkwF2FhkexgyKq/NIZdPdknhHf5A/Ww==}
+  valibot@1.0.0-beta.0:
+    resolution: {integrity: sha512-Q/oine+NPMXdIy3vwluw0vidHLk0mTPUQBRHc+EHZXnEWF3KzLx1YLsVHPVrgHaMGRfV58P9eGOgxJvi0a059w==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -2836,7 +2841,9 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
-  valibot@0.35.0: {}
+  valibot@1.0.0-beta.0(typescript@5.4.5):
+    optionalDependencies:
+      typescript: 5.4.5
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
I've updated the Valibot dependency to v1. We've changed the type signature, so this change is necessary. All other changes in our v1 beta version are only internal.