### PR TITLE
fix: valibot peer dependency version to support dist-tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 	},
 	"peerDependencies": {
 		"@mantine/form": ">=7.0.0",
-		"valibot": ">=1.0.0"
+		"valibot": ">=1.0.0 || ^1.0.0-beta || ^1.0.0-rc"
 	},
 	"packageManager": "pnpm@9.12.0",
 	"engines": {


### PR DESCRIPTION
Looks like the npm install broke with the upgrade to Valibot v1. This PR should fix that.